### PR TITLE
Added Laser cut (unoptimized) to keep path vertex order.

### DIFF
--- a/src/components/operation-diagram.js
+++ b/src/components/operation-diagram.js
@@ -45,7 +45,7 @@ const hide = [
 
 const types = {
     'Laser Cut': { show: ['LaserCut'] },
-    'Laser (unoptimized)': { show: ['LaserCut'] },
+    'Laser Cut (unoptimized)': { show: ['LaserCut'] },
     'Laser Cut Inside': { show: ['LaserCutInside', 'laserDia'] },
     'Laser Cut Outside': { show: ['LaserCutOutside', 'laserDia'] },
     'Laser Fill Path': { show: ['LaserFill', 'lineSpace'] },

--- a/src/components/operation-diagram.js
+++ b/src/components/operation-diagram.js
@@ -45,6 +45,7 @@ const hide = [
 
 const types = {
     'Laser Cut': { show: ['LaserCut'] },
+    'Laser (unoptimized)': { show: ['LaserCut'] },
     'Laser Cut Inside': { show: ['LaserCutInside', 'laserDia'] },
     'Laser Cut Outside': { show: ['LaserCutOutside', 'laserDia'] },
     'Laser Fill Path': { show: ['LaserFill', 'lineSpace'] },

--- a/src/components/operation.js
+++ b/src/components/operation.js
@@ -580,6 +580,7 @@ const tabFields = [
 
 export const OPERATION_TYPES = {
     'Laser Cut': { allowTabs: true, tabFields: false, fields: ['name', 'filterFillColor', 'filterStrokeColor', 'laserPower', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useA', 'aAxisDiameter', 'useBlower', 'segmentLength', ...OPERATION_GROUPS.Macros.fields] },
+    'Laser Cut (unoptimized)': { allowTabs: true, tabFields: false, fields: ['name', 'filterFillColor', 'filterStrokeColor', 'laserPower', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useA', 'aAxisDiameter', 'useBlower', 'segmentLength', ...OPERATION_GROUPS.Macros.fields] },
     'Laser Cut Inside': { allowTabs: true, tabFields: false, fields: ['name', 'filterFillColor', 'filterStrokeColor', 'laserDiameter', 'laserPower', 'margin', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useA', 'aAxisDiameter', 'useBlower', 'segmentLength', ...OPERATION_GROUPS.Macros.fields] },
     'Laser Cut Outside': { allowTabs: true, tabFields: false, fields: ['name', 'filterFillColor', 'filterStrokeColor', 'laserDiameter', 'laserPower', 'margin', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useA', 'aAxisDiameter', 'useBlower', 'segmentLength', ...OPERATION_GROUPS.Macros.fields] },
     'Laser Fill Path': { allowTabs: false, tabFields: false, fields: ['name', 'filterFillColor', 'filterStrokeColor', 'lineDistance', 'lineAngle', 'laserPower', 'margin', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useA', 'aAxisDiameter', 'useBlower', ...OPERATION_GROUPS.Macros.fields] },

--- a/src/lib/cam-gcode-laser-cut.js
+++ b/src/lib/cam-gcode-laser-cut.js
@@ -165,7 +165,7 @@ export function getLaserCutGcode(props) {
 export function getLaserCutGcodeFromOp(settings, opIndex, op, geometry, openGeometry, tabGeometry, showAlert, done, progress) {
     let ok = true;
 
-    if (op.type !== 'Laser Cut' && op.type !== 'Laser Fill Path') {
+    if (op.type !== 'Laser Cut' && op.type !== 'Laser Cut (unoptimized)' && op.type !== 'Laser Fill Path') {
         if (op.laserDiameter <= 0) {
             showAlert("Laser Diameter must be greater than 0", "danger");
             ok = false;
@@ -210,6 +210,8 @@ export function getLaserCutGcodeFromOp(settings, opIndex, op, geometry, openGeom
     let camPaths = [];
     if (op.type === 'Laser Cut') {
         camPaths = cut(geometry, openGeometry, false);
+    } else if (op.type === 'Laser Cut (unoptimized)') {
+        camPaths = cut(geometry, openGeometry, false, false);
     } else if (op.type === 'Laser Cut Inside') {
         if (op.margin)
             geometry = offset(geometry, -op.margin * mmToClipperScale);

--- a/src/lib/cam-gcode.js
+++ b/src/lib/cam-gcode.js
@@ -144,7 +144,7 @@ export function getGcode(settings, documents, operations, documentCacheHolder, s
                 .then((preflight) => {
                     let { geometry, openGeometry, tabGeometry, filteredDocIds, docsWithImages } = preflight;
                     console.log('Queueing Worker: ' + op.type + "->" + opIndex);
-                    if (op.type === 'Laser Cut' || op.type === 'Laser Cut Inside' || op.type === 'Laser Cut Outside' || op.type === 'Laser Fill Path') {
+                    if (op.type === 'Laser Cut' || op.type === 'Laser Cut (unoptimized)' || op.type === 'Laser Cut Inside' || op.type === 'Laser Cut Outside' || op.type === 'Laser Fill Path') {
                         laserOps = true;
                         if (startCode === "") startCode = settings.gcodeStart;
                         if (endCode === "") endCode = settings.gcodeEnd;


### PR DESCRIPTION
Adding a new cutting option so the vertex order is preserved. This is useful when piercing is needed and the first vertex is where the piercing must happen.
Maybe someday we'll add a separate option for each processing selection (laser cut, fill, milling, etc) so different optimizers could be used such as TSP implementations, but before this happen this option is hopefully useful to users.