### PR TITLE
Small fixes for material database and operation  reordering

### DIFF
--- a/src/reducers/operation.js
+++ b/src/reducers/operation.js
@@ -2,7 +2,7 @@
 
 import { getParentIds, object, objectArray } from '../reducers/object'
 
-import arrayMove from 'array-move'
+import {arrayMoveImmutable} from 'array-move';
 
 import { GlobalStore } from '../index';
 
@@ -147,7 +147,7 @@ export const operations = (state, action) => {
                 newIndex = 0;
             if (newIndex > state.length - 1)
                 newIndex = state.length - 1;
-            return arrayMove(state.slice(), index, newIndex);
+            return arrayMoveImmutable(state.slice(), index, newIndex);
         case 'OPERATION_SET_ATTRS':
             if (action.payload.attrs.expanded)
                 state = state.map(op => ({ ...op, expanded: op.id === action.payload.id }));

--- a/src/styles/material-database.css
+++ b/src/styles/material-database.css
@@ -20,15 +20,15 @@
 .details {margin-top: 2px; margin-left: 10px}
 .details .handler {display:flex; flex-direction: row; align-items: center; flex-grow:2}
 .details .handler > * {flex-grow:1}
-.details heading button {margin-left: 5px}
-.details heading {display:flex;margin:0}
-.details heading .summary { display:flex; flex-grow:1}
-.details heading .summary small {margin-left: 1em}
+.details h5 button {margin-left: 5px}
+.details h5 {display:flex;margin:0}
+.details h5 .summary { display:flex; flex-grow:1}
+.details h5 .summary small {margin-left: 1em}
 
-.details heading .summary > * {margin-top:0}
-.details:hover  heading {background: rgba(0, 126, 255, 0.08); border-radius: 5px}
+.details h5 .summary > * {margin-top:0}
+.details:hover  h5 {background: rgba(0, 126, 255, 0.08); border-radius: 5px}
 
-.materialPicker  > section > heading  {display:flex; flex-direction: row; align-items: center; border-bottom: 1px solid #eee; }
+.materialPicker  > section > h5  {display:flex; flex-direction: row; align-items: center; border-bottom: 1px solid #eee; }
 .materialPicker table {font-size: 0.8em; margin-left: 1.2em; width: 98%; margin-top:0.5em}
 .materialPicker table td, 
 .materialPicker table th {padding: 2px !important}


### PR DESCRIPTION
Updated material-database.css to reflect change from heading to h5 which fixed the material picker layout

\>1.0 array-move node module no longer provides arrayMove function, updated to use arrayMoveImmutable to restore operation reordering